### PR TITLE
Removed required from search text box

### DIFF
--- a/rot/apps/frontend/forms.py
+++ b/rot/apps/frontend/forms.py
@@ -57,5 +57,5 @@ class SearchForm(forms.Form):
         ('owner.raw', 'Owner (asc)'),
         ('-owner.raw', 'Owner (desc)'),
     )
-    search = forms.CharField(max_length=100)
+    search = forms.CharField(max_length=100, required=False)
     sort = forms.ChoiceField(choices=SORT_CHOICES, required=False)


### PR DESCRIPTION
When paginating or sorting, if the search box was empty, an error showed. Making the search field not required fixes this.